### PR TITLE
Add `--install-links` flag to npm install command

### DIFF
--- a/tpl/superdesk-analytics/build.sh
+++ b/tpl/superdesk-analytics/build.sh
@@ -4,4 +4,4 @@ cd {{repo_server}}
 pip install -Ue ../analytics
 
 cd {{repo_client}}
-npm install ../analytics
+npm install ../analytics --install-links


### PR DESCRIPTION
Updates the npm install command in the build script to include the --install-links flag when installing the analytics package. This is required for proper linking of dependencies.